### PR TITLE
Add refiner for start of day

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - 8
+notifications:
+  disabled: true

--- a/index.js
+++ b/index.js
@@ -2,6 +2,14 @@ const chrono = require('chrono-node')
 
 const matcher = /^remind (me)(?: to )?(.*)$/
 
+const parser = new chrono.Chrono()
+parser.refiners.push(require('./lib/refiners/start-of-day'))
+
+const options = {
+  forwardDate: true,
+  startOfDay: 9
+}
+
 module.exports = (input, from) => {
   const match = input.match(matcher)
   if (!match) {
@@ -13,7 +21,7 @@ module.exports = (input, from) => {
   let [, who, what] = match
 
   // Use chrono to extract the `when` from the `what`
-  const when = chrono.parse(what, from, {forwardDate: true})
+  const when = parser.parse(what, from, options)
 
   // Remove any time expressions from the `what`
   when.forEach(w => {

--- a/lib/refiners/start-of-day.js
+++ b/lib/refiners/start-of-day.js
@@ -1,0 +1,14 @@
+module.exports = {
+  refine (text, results, opt) {
+    if (opt.startOfDay) {
+      results.forEach(result => {
+        if (!result.start.isCertain('hour')) {
+          result.start.imply('hour', opt.startOfDay)
+          result.tags['StartOfWorkDayRefiner'] = true
+        }
+      })
+    }
+
+    return results
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -11,8 +11,7 @@ describe('parse-reminder', () => {
     'nothing to see here': null,
 
     'remind me to call the doctor tomorrow': {
-      // FIXME: add refiner to prefer 9am for dates without a time
-      who: 'me', when: new Date(2017, 6, 6, 12, 0, 0, 0), what: 'call the doctor'
+      who: 'me', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'call the doctor'
     },
 
     'remind me to send invites at 3pm tomorrow': {
@@ -20,11 +19,11 @@ describe('parse-reminder', () => {
     },
 
     'remind me 8/28 to wish Jamie happy birthday': {
-      who: 'me', when: new Date(2017, 7, 28, 12, 0, 0, 0), what: 'wish Jamie happy birthday'
+      who: 'me', when: new Date(2017, 7, 28, 9, 0, 0, 0), what: 'wish Jamie happy birthday'
     },
 
     'remind me to wish Jamie happy birthday on 8/28': {
-      who: 'me', when: new Date(2017, 7, 28, 12, 0, 0, 0), what: 'wish Jamie happy birthday'
+      who: 'me', when: new Date(2017, 7, 28, 9, 0, 0, 0), what: 'wish Jamie happy birthday'
     },
 
     'remind me in 10 minutes to change the laundry': {
@@ -36,15 +35,15 @@ describe('parse-reminder', () => {
     },
 
     'remind me on 18 Feb to be alive': {
-      who: 'me', when: new Date(2018, 1, 18, 12, 0, 0, 0), what: 'be alive'
+      who: 'me', when: new Date(2018, 1, 18, 9, 0, 0, 0), what: 'be alive'
     },
 
     'remind me Tuesday to watch pogo': {
-      who: 'me', when: new Date(2017, 6, 11, 12, 0, 0, 0), what: 'watch pogo'
+      who: 'me', when: new Date(2017, 6, 11, 9, 0, 0, 0), what: 'watch pogo'
     },
 
     'remind me Tuesday': {
-      who: 'me', when: new Date(2017, 6, 11, 12, 0, 0, 0), what: ''
+      who: 'me', when: new Date(2017, 6, 11, 9, 0, 0, 0), what: ''
     },
 
     'remind me to go to the dentist on Aug 4 at 3': {
@@ -53,11 +52,11 @@ describe('parse-reminder', () => {
     },
 
     'remind me to followup with Kathy in 2 weeks': {
-      who: 'me', when: new Date(2017, 6, 19, 12, 0, 0, 0), what: 'followup with Kathy'
+      who: 'me', when: new Date(2017, 6, 19, 9, 0, 0, 0), what: 'followup with Kathy'
     },
 
     'remind me in 2 weeks to followup with Kathy': {
-      who: 'me', when: new Date(2017, 6, 19, 12, 0, 0, 0), what: 'followup with Kathy'
+      who: 'me', when: new Date(2017, 6, 19, 9, 0, 0, 0), what: 'followup with Kathy'
     },
 
     'remind me at 4:00 to check in with Dan': {
@@ -65,17 +64,17 @@ describe('parse-reminder', () => {
       who: 'me', when: new Date(2017, 6, 5, 4, 0, 0, 0), what: 'check in with Dan'
     },
 
-    'remind me 9am to go to work': {
+    'remind me 10am to go to work': {
       // FIXME: fix future refiner to work with times later in the day
-      who: 'me', when: new Date(2017, 6, 5, 9, 0, 0, 0), what: 'go to work'
+      who: 'me', when: new Date(2017, 6, 5, 10, 0, 0, 0), what: 'go to work'
     },
 
     'remind me that the oil needs changed on Oct 4': {
-      who: 'me', when: new Date(2017, 9, 4, 12, 0, 0, 0), what: 'the oil needs changed'
+      who: 'me', when: new Date(2017, 9, 4, 9, 0, 0, 0), what: 'the oil needs changed'
     },
 
     'remind me next Friday to open the pod bay doors': {
-      who: 'me', when: new Date(2017, 6, 14, 12, 0, 0, 0), what: 'open the pod bay doors'
+      who: 'me', when: new Date(2017, 6, 14, 9, 0, 0, 0), what: 'open the pod bay doors'
     },
 
     'remind me tomorrow at noon to buy the new iPhone': {


### PR DESCRIPTION
This adds a refiner to allow setting the preferred hour to start the day. For reminders where the hour is not precise (e.g. "remind me to take out the trash tomorrow"), it will default to 9am instead of 12pm.