### PR TITLE
Return null if no date

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,11 @@ module.exports = (input, from) => {
   // Use chrono to extract the `when` from the `what`
   const when = parser.parse(what, from, options)
 
+  if (when.length < 1) {
+    // What kind of reminder doesn't have a date?
+    return null
+  }
+
   // Remove any time expressions from the `what`
   when.forEach(w => {
     what = what.replace(w.text, '')

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,8 @@ describe('parse-reminder', () => {
   const examples = {
     'nothing to see here': null,
 
+    'remind me nope': null,
+
     'remind me to call the doctor tomorrow': {
       who: 'me', when: new Date(2017, 6, 6, 9, 0, 0, 0), what: 'call the doctor'
     },


### PR DESCRIPTION
Add condition to ensure it returns null when no date is present. Eventually there might be use cases where this should still return a reminder with a null date, but that's not my use case right now.